### PR TITLE
[Fixes #40] Fix compatibility with newer versions of Minecraft and Meteor

### DIFF
--- a/src/main/java/cally72jhb/addon/VectorAddon.java
+++ b/src/main/java/cally72jhb/addon/VectorAddon.java
@@ -8,7 +8,7 @@ import cally72jhb.addon.modules.player.*;
 import cally72jhb.addon.modules.render.*;
 import cally72jhb.addon.utils.ExecutorTask;
 import meteordevelopment.meteorclient.addons.MeteorAddon;
-import meteordevelopment.meteorclient.systems.commands.Commands;
+import meteordevelopment.meteorclient.commands.Commands;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,13 +61,13 @@ public class VectorAddon extends MeteorAddon {
 
         // Commands
 
-        Commands.get().add(new CenterCommand());
-        Commands.get().add(new DesyncCommand());
-        Commands.get().add(new ItemCommand());
-        Commands.get().add(new PlayerHeadCommand());
-        Commands.get().add(new TeleportCommand());
-        Commands.get().add(new TrashCommand());
-        Commands.get().add(new UUIDCommand());
+        Commands.add(new CenterCommand());
+        Commands.add(new DesyncCommand());
+        Commands.add(new ItemCommand());
+        Commands.add(new PlayerHeadCommand());
+        Commands.add(new TeleportCommand());
+        Commands.add(new TrashCommand());
+        Commands.add(new UUIDCommand());
 
         // Done Initializing
 

--- a/src/main/java/cally72jhb/addon/commands/commands/CenterCommand.java
+++ b/src/main/java/cally72jhb/addon/commands/commands/CenterCommand.java
@@ -1,11 +1,12 @@
 package cally72jhb.addon.commands.commands;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import meteordevelopment.meteorclient.systems.commands.Command;
+import meteordevelopment.meteorclient.commands.Command;
 import net.minecraft.command.CommandSource;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class CenterCommand extends Command {
     public CenterCommand() {

--- a/src/main/java/cally72jhb/addon/commands/commands/DesyncCommand.java
+++ b/src/main/java/cally72jhb/addon/commands/commands/DesyncCommand.java
@@ -1,12 +1,13 @@
 package cally72jhb.addon.commands.commands;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import meteordevelopment.meteorclient.systems.commands.Command;
+import meteordevelopment.meteorclient.commands.Command;
 import net.minecraft.command.CommandSource;
 import net.minecraft.entity.Entity;
 import net.minecraft.network.packet.c2s.play.TeleportConfirmC2SPacket;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class DesyncCommand extends Command {
     private Entity entity = null;

--- a/src/main/java/cally72jhb/addon/commands/commands/ItemCommand.java
+++ b/src/main/java/cally72jhb/addon/commands/commands/ItemCommand.java
@@ -5,7 +5,7 @@ import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import meteordevelopment.meteorclient.systems.commands.Command;
+import meteordevelopment.meteorclient.commands.Command;
 import net.minecraft.command.CommandSource;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.packet.c2s.play.ClickSlotC2SPacket;
@@ -17,6 +17,7 @@ import net.minecraft.util.collection.DefaultedList;
 import java.util.List;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class ItemCommand extends Command {
     public ItemCommand() {

--- a/src/main/java/cally72jhb/addon/commands/commands/PlayerHeadCommand.java
+++ b/src/main/java/cally72jhb/addon/commands/commands/PlayerHeadCommand.java
@@ -9,7 +9,7 @@ import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
-import meteordevelopment.meteorclient.systems.commands.Command;
+import meteordevelopment.meteorclient.commands.Command;
 import net.minecraft.command.CommandSource;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -20,6 +20,7 @@ import net.minecraft.util.math.MathHelper;
 import java.util.Random;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class PlayerHeadCommand extends Command {
     private final static SimpleCommandExceptionType NO_CREATIVE = new SimpleCommandExceptionType(Text.literal("You must be in creative mode to use this."));

--- a/src/main/java/cally72jhb/addon/commands/commands/TeleportCommand.java
+++ b/src/main/java/cally72jhb/addon/commands/commands/TeleportCommand.java
@@ -4,7 +4,7 @@ import cally72jhb.addon.commands.arguments.PositionArgumentType;
 import com.mojang.brigadier.arguments.FloatArgumentType;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import meteordevelopment.meteorclient.systems.commands.Command;
+import meteordevelopment.meteorclient.commands.Command;
 import net.minecraft.command.CommandSource;
 import net.minecraft.entity.Entity;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
@@ -12,6 +12,7 @@ import net.minecraft.network.packet.c2s.play.VehicleMoveC2SPacket;
 import net.minecraft.util.math.Vec3d;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class TeleportCommand extends Command {
     public TeleportCommand() {

--- a/src/main/java/cally72jhb/addon/commands/commands/TrashCommand.java
+++ b/src/main/java/cally72jhb/addon/commands/commands/TrashCommand.java
@@ -2,11 +2,12 @@ package cally72jhb.addon.commands.commands;
 
 import cally72jhb.addon.utils.Utils;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import meteordevelopment.meteorclient.systems.commands.Command;
+import meteordevelopment.meteorclient.commands.Command;
 import net.minecraft.command.CommandSource;
 import net.minecraft.screen.slot.SlotActionType;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class TrashCommand extends Command {
     public TrashCommand() {

--- a/src/main/java/cally72jhb/addon/commands/commands/UUIDCommand.java
+++ b/src/main/java/cally72jhb/addon/commands/commands/UUIDCommand.java
@@ -2,11 +2,12 @@ package cally72jhb.addon.commands.commands;
 
 import cally72jhb.addon.commands.arguments.PlayerArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import meteordevelopment.meteorclient.systems.commands.Command;
+import meteordevelopment.meteorclient.commands.Command;
 import net.minecraft.command.CommandSource;
 import net.minecraft.entity.player.PlayerEntity;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;
+import static meteordevelopment.meteorclient.MeteorClient.mc;
 
 public class UUIDCommand extends Command {
     public UUIDCommand() {

--- a/src/main/java/cally72jhb/addon/modules/player/ItemRelease.java
+++ b/src/main/java/cally72jhb/addon/modules/player/ItemRelease.java
@@ -15,7 +15,7 @@ import net.minecraft.network.packet.c2s.play.PlayerInteractItemC2SPacket;
 import net.minecraft.util.UseAction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
-import net.minecraft.util.registry.Registry;
+import net.minecraft.registry.Registries;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -77,7 +77,7 @@ public class ItemRelease extends Module {
 
     private List<Item> getDefaultItems() {
         List<Item> items = new ArrayList<>();
-        for (Item item : Registry.ITEM) if (itemFilter(item)) items.add(item);
+        for (Item item : Registries.ITEM) if (itemFilter(item)) items.add(item);
 
         return items;
     }


### PR DESCRIPTION
Meteor recently did some API changes that broke addon compatibility, which require manual update by the devs of the addons. Outdated addons will cause a crash at startup. Because this addon is affected, I fixed it. Additionally, Vector wouldn't compile under newer versions of Fabric, so I also fixed that. Fixed #40 